### PR TITLE
add client and server udp connection interface

### DIFF
--- a/protocol/main.go
+++ b/protocol/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("vim-go")
-}

--- a/rftp/client.go
+++ b/rftp/client.go
@@ -1,0 +1,41 @@
+package rftp
+
+import (
+	"encoding"
+	"io"
+)
+
+var defaultRequester = UDPRequester{}
+
+var defaultClient = Client{
+	&defaultRequester,
+}
+
+func Request(host string, files []string) ([]io.Reader, error) {
+	return defaultClient.Request(host, files)
+}
+
+type Requester interface {
+	Request(string, encoding.BinaryMarshaler) (encoding.BinaryUnmarshaler, error)
+}
+
+type Client struct {
+	Transport Requester
+}
+
+func (c Client) Request(host string, files []string) ([]io.Reader, error) {
+	fs := []FileRequest{}
+	for _, f := range files {
+		fs = append(fs, FileRequest{0, f})
+	}
+
+	cr := ClientRequest{fs}
+	_, err := c.Transport.Request(host, cr)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: convert r into a list of reader and return it
+
+	return nil, nil
+}

--- a/rftp/client_test.go
+++ b/rftp/client_test.go
@@ -1,0 +1,19 @@
+package rftp_test
+
+import (
+	"testing"
+
+	"github.com/hendrikcech/rft/rftp"
+)
+
+func checkErr(t *testing.T, err error) {
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestClient(t *testing.T) {
+	c := &rftp.Client{}
+	_, err := c.Request("localhost:8000", []string{"File"})
+	checkErr(t, err)
+}

--- a/rftp/connection.go
+++ b/rftp/connection.go
@@ -1,0 +1,65 @@
+package rftp
+
+import (
+	"encoding"
+	"io"
+	"net"
+)
+
+type UDPRequester struct {
+	conn *net.UDPConn
+}
+
+func (u *UDPRequester) Dial(host string) error {
+	addr, err := net.ResolveUDPAddr("udp", host)
+	if err != nil {
+		return err
+	}
+
+	conn, err := net.DialUDP("udp", nil, addr)
+
+	if err != nil {
+		return err
+	}
+
+	u.conn = conn
+	return nil
+}
+
+func (u *UDPRequester) Request(host string, m encoding.BinaryMarshaler) (encoding.BinaryUnmarshaler, error) {
+
+	msg, err := m.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	err = u.Dial(host)
+	if err != nil {
+		return nil, err
+	}
+
+	err = send(msg, u.conn)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: now receive the file request response packet
+	// and then receive all the data packets and send corresponding acks
+
+	r := make([]byte, 1024)
+	_, _, err = u.conn.ReadFromUDP(r)
+
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func send(data []byte, w io.Writer) error {
+	_, err := w.Write(data)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/rftp/doc.go
+++ b/rftp/doc.go
@@ -1,0 +1,2 @@
+// Package rftp implements the RFT-Protocol
+package rftp

--- a/rftp/msgs.go
+++ b/rftp/msgs.go
@@ -1,4 +1,4 @@
-package main
+package rftp
 
 import (
 	"bytes"

--- a/rftp/msgs_test.go
+++ b/rftp/msgs_test.go
@@ -1,4 +1,4 @@
-package main
+package rftp
 
 import (
 	"encoding"

--- a/rftp/server.go
+++ b/rftp/server.go
@@ -1,0 +1,38 @@
+package rftp
+
+import (
+	"net"
+	"os"
+)
+
+type Lister interface {
+	List() ([]os.FileInfo, error)
+}
+
+type Server struct {
+	SRC Lister
+}
+
+func (s *Server) Listen(host string) error {
+	addr, err := net.ResolveUDPAddr("udp", host)
+	if err != nil {
+		return err
+	}
+
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		return err
+	}
+
+	defer conn.Close()
+
+	for {
+		msg := make([]byte, 1024)
+		_, addr, err := conn.ReadFromUDP(msg)
+		if err != nil {
+			return err
+		}
+
+		conn.WriteToUDP(msg, addr)
+	}
+}

--- a/rftp/server_test.go
+++ b/rftp/server_test.go
@@ -1,0 +1,22 @@
+package rftp_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/hendrikcech/rft/rftp"
+)
+
+type files string
+
+func (fl files) List() ([]os.FileInfo, error) {
+	return ioutil.ReadDir(string(fl))
+}
+
+func TestServer(t *testing.T) {
+	s := rftp.Server{
+		SRC: files("."),
+	}
+	s.Listen("localhost:8080")
+}


### PR DESCRIPTION
Very rough implementation of UDP-client and -server. Sorry, I renamed the `protocol`-package again, because I realized `rftp.Request` or `rftp.Server` might be better than just `protocol.Request` or `protocol.Server`.

The tests are almost empty and only show how I'd like to use the rftp package as a user (like the `cmd`-package will do later).

Feel free to feedback in comments or add or remove code.