### PR TITLE
Print error if server returned error status in metadata

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -80,6 +80,10 @@ var rootCmd = &cobra.Command{
 			log.Println("finish write")
 		}
 
+		// TODO: remove. Without this not all goroutines are finishing. For example,
+		// waitForCloseConnection does not process the write to the done channel by
+		// the last processed FileResponse.
+		time.Sleep(1 * time.Millisecond)
 	},
 }
 

--- a/rftp/client.go
+++ b/rftp/client.go
@@ -99,7 +99,11 @@ func (c *Client) waitForCloseConnection() {
 	done := 0
 	for {
 		select {
-		case <-c.done:
+		case i := <-c.done:
+			fr := c.responses[i]
+			if fr.err != nil {
+				log.Printf("Transfer of file %v aborted: %s", i, fr.err)
+			}
 			done++
 			if done == len(c.responses) {
 				c.closeConnection()


### PR DESCRIPTION
Do you have an idea how the problem targeted by the sleep in cmd.go could be solved in a cleaner way?